### PR TITLE
Corrected README.md && abs() function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ lab.To<ColorSpace::Cmy>(&cmy);
 You can compare colors by using the ```Compare``` method of each comparison class:
 ```c++
 ColorSpace::Lab a(100, 0, 0);
-ColorSpace::RGb b(255, 255, 255);
+ColorSpace::Rgb b(255, 255, 255);
 ColorSpace::Cie2000Comparison::Compare(&a, &b);
 ```
 

--- a/src/Comparison.cpp
+++ b/src/Comparison.cpp
@@ -98,7 +98,7 @@ namespace ColorSpace {
 		if (c1*c2 < eps) {
 			deltah = 0;
 		}
-		if (abs(h2 - h1) <= M_PI) {
+		if (std::abs(h2 - h1) <= M_PI) {
 			deltah = h2 - h1;
 		}
 		else if (h2 > h1) {
@@ -119,7 +119,7 @@ namespace ColorSpace {
 		if (c1*c2 < eps) {
 			meanH = h1 + h2;
 		}
-		if (abs(h1 - h2) <= M_PI + eps) {
+		if (std::abs(h1 - h2) <= M_PI + eps) {
 			meanH = (h1 + h2) / 2;
 		}
 		else if (h1 + h2 < 2*M_PI) {
@@ -158,7 +158,7 @@ namespace ColorSpace {
 		double deltaH = 0;
 
 		double f = sqrt(POW4(lch_a.c) / (POW4(lch_a.c) + 1900));
-		double t = (164 <= lch_a.h && lch_a.h <= 345) ? (0.56 + abs(0.2*cos(lch_a.h + 168))) : (0.36 + abs(0.4*cos(lch_a.h + 35)));
+		double t = (164 <= lch_a.h && lch_a.h <= 345) ? (0.56 + std::abs(0.2*cos(lch_a.h + 168))) : (0.36 + abs(0.4*cos(lch_a.h + 35)));
 
 		double sl = (lch_a.l < 16) ? 0.511 : (0.040975*lch_a.l / (1 + 0.01765*lch_a.l));
 		double sc = 0.0638*lch_a.c / (1 + 0.0131*lch_a.c) + 0.638;

--- a/src/Conversion.cpp
+++ b/src/Conversion.cpp
@@ -81,7 +81,7 @@ namespace ColorSpace {
 				item->s = delta / (max + min) * 100;
 			}
 			else {
-				item->s = delta / (1 - abs(2 * item->l - 1)) * 100;
+				item->s = delta / (1 - std::abs(2 * item->l - 1)) * 100;
 			}
 
 			if (r == max) {
@@ -256,7 +256,7 @@ namespace ColorSpace {
 		k = std::min(k, cmy.y);
 
 		item->k = k;
-		if (abs(item->k - 1) < 1e-3) {
+		if (std::abs(item->k - 1) < 1e-3) {
 			item->c = 0;
 			item->m = 0;
 			item->y = 0;
@@ -309,7 +309,7 @@ namespace ColorSpace {
 	void HsvConverter::ToColor(Rgb *color, Hsv *item) {
 		int range = (int)floor(item->h / 60);
 		double c = item->v*item->s;
-		double x = c*(1 - abs(fmod(item->h / 60, 2) - 1));
+		double x = c*(1 - std::abs(fmod(item->h / 60, 2) - 1));
 		double m = item->v - c;
 
 		switch (range) {


### PR DESCRIPTION
I corrected a small typo in the `README `file for those (like me) who like to copy and paste for a quick test.
I also updated the function call to the math function `abs()` to the full namespace call `std::abs()`.
For some reason `g++/nvcc` complained about `abs()` and my program wouldn't compile unless I call `std::abs()`. I am not using `using namespace std` in my program, so that may be why.

Great library overall!