### PR TITLE
Bugfix in EuclideanComparison

### DIFF
--- a/src/Comparison.cpp
+++ b/src/Comparison.cpp
@@ -10,7 +10,7 @@ namespace ColorSpace {
 		a->ToRgb(&rgb_a);
 		b->ToRgb(&rgb_b);
 
-		return sqrt(SQR(rgb_a.r - rgb_b.r) + SQR(rgb_a.g - rgb_b.g) + SQR(rgb_a.b - rgb_a.b));
+		return sqrt(SQR(rgb_a.r - rgb_b.r) + SQR(rgb_a.g - rgb_b.g) + SQR(rgb_a.b - rgb_b.b));
 	}
 
 	double Cie1976Comparison::Compare(IColorSpace *a, IColorSpace *b) {


### PR DESCRIPTION
In the `EuclideanComparison` the `b` channel of `rgb_b` is not used and the `b` channel of `rgb_a` is used twice instead. 